### PR TITLE
Test sf container integration and remove framework-bundle from deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,13 @@
   },
   "require": {
     "php": "^7.0",
-    "symfony/framework-bundle": "^2.3|^3.0|^4.0",
-    "symfony/http-foundation": "^2.3.32|^3.0|^4.0"
+    "symfony/http-foundation": "^2.3.32|^3.0|^4.0",
+    "symfony/http-kernel": "^2.3|^3.0|^4.0",
+    "symfony/dependency-injection": "^2.3|^3.0|^4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5|^7.5"
+    "phpunit/phpunit": "^6.5|^7.5",
+    "matthiasnoback/symfony-dependency-injection-test": "^2.3|^3.0"
   },
   "extra": {
     "branch-alias": {

--- a/src/DependencyInjection/GoetasMultipartUploadExtension.php
+++ b/src/DependencyInjection/GoetasMultipartUploadExtension.php
@@ -4,8 +4,8 @@ namespace Goetas\MultipartUploadBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class GoetasMultipartUploadExtension extends Extension
 {

--- a/tests/DependencyInjection/MultipartRequestListenerTest.php
+++ b/tests/DependencyInjection/MultipartRequestListenerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Goetas\MultipartUploadBundle\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+
+class MultipartRequestListenerTest extends AbstractExtensionTestCase
+{
+    protected function getContainerExtensions()
+    {
+        return array(
+            new GoetasMultipartUploadExtension()
+        );
+    }
+
+    public function testListenerIsRegistered()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'goetas.multipart_upload.request_listener',
+            'kernel.event_listener',
+            ['event' => 'kernel.request', 'method' => 'onKernelRequest', 'priority' => 200]
+        );
+    }
+}

--- a/tests/EventListener/MultipartRequestListenerTest.php
+++ b/tests/EventListener/MultipartRequestListenerTest.php
@@ -5,8 +5,6 @@ namespace Goetas\MultipartUploadBundle\EventListener;
 use Goetas\MultipartUploadBundle\Exception\MultipartProcessorException;
 use Goetas\MultipartUploadBundle\RelatedPart;
 use Goetas\MultipartUploadBundle\TestKernel;
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
@@ -37,7 +35,6 @@ class MultipartRequestListenerTest extends TestCase
 
         $this->request = new Request();
         $this->event = new GetResponseEvent(new TestKernel(), $this->request, HttpKernelInterface::MASTER_REQUEST);
-        error_reporting(E_ALL);
     }
 
     /**


### PR DESCRIPTION
Why we require `symfony/framework-bundle` as we only need `symfony/http-foundation`

So allow to install this component on projects like `Silex` and micro-kernel