### PR TITLE
FIX small typo AND compatibility with Sf<4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 cache:
   directories:
     - $HOME/.composer/cache/files
-    -
+
 matrix:
   fast_finish: true
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ X-Custom-Header: header value
 
 --19D523FB--
 ```
+
 ## Usage
 ### Controller
 Body will not be decoded automatically, you can decode it by yourself or use [FOSRestBundle](https://github.com/FriendsOfSymfony/FOSRestBundle) to handle it transparently 

--- a/src/EventListener/MultipartRequestListener.php
+++ b/src/EventListener/MultipartRequestListener.php
@@ -85,7 +85,7 @@ class MultipartRequestListener
                     if ('error' === $params[3]->getName()) { // symfony 4
                         $file = new UploadedFile($tmpPath, urldecode($fileName), $part->getMimeType(), null, true);
                     } else { // symfony < 4
-                        $file = new UploadedFile($tmpPath, urldecode($fileName), $part->getMimeType(), filesize($tmpPath), null, false);
+                        $file = new UploadedFile($tmpPath, urldecode($fileName), $part->getMimeType(), filesize($tmpPath), null, true);
                     }
                     @$file->ref = $fp;
                     $attachments[] = $file;

--- a/tests/EventListener/MultipartRequestListenerTest.php
+++ b/tests/EventListener/MultipartRequestListenerTest.php
@@ -293,7 +293,7 @@ class MultipartRequestListenerTest extends TestCase
         self::assertEquals('Content', file_get_contents($attachment->getPathname()));
         self::assertEquals('Nome file.pdf', $attachment->getClientOriginalName());
         self::assertEquals('mime/type', $attachment->getClientMimeType());
-        self::assertEquals(0, $attachment->getError());
+        self::assertTrue($attachment->isValid());
     }
 
     private function setRequestContent($content)


### PR DESCRIPTION
Fix compatibility with `Symfony < 4`, solves https://github.com/goetas/MultipartUploadBundle/issues/8
Fix small typo in `README.md` and `travis.yml` files
Update tests