### PR TITLE
Allow Symfony5 and PHP8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /phpunit.xml
+/.phpunit.result.cache
 /.php_cs.cache
 /.idea
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
+  - 8.0
   - nightly
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
     }
   },
   "require": {
-    "php": "^7.0",
-    "symfony/http-foundation": "^2.3.32|^3.0|^4.0",
-    "symfony/http-kernel": "^2.3|^3.0|^4.0",
-    "symfony/dependency-injection": "^2.3|^3.0|^4.0",
+    "php": "^7.1|^8.0",
+    "symfony/http-foundation": "^4.1.1|^5.0",
+    "symfony/http-kernel": "^4.3|^5.0",
+    "symfony/dependency-injection": "^2.3|^3.0|^4.0|^5.0",
     "riverline/multipart-parser": "^2.0.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5|^7.5",
-    "matthiasnoback/symfony-dependency-injection-test": "^2.3|^3.0"
+    "phpunit/phpunit": "^7.5|^8.5|^9.5",
+    "matthiasnoback/symfony-dependency-injection-test": "^3.0|^4.0"
   },
   "extra": {
     "branch-alias": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,7 +7,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-
     public function getConfigTreeBuilder()
     {
         $tb = new TreeBuilder('goetas_multipart_upload');

--- a/src/EventListener/MultipartRequestListener.php
+++ b/src/EventListener/MultipartRequestListener.php
@@ -6,7 +6,7 @@ use Riverline\MultiPartParser\Converters\HttpFoundation;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class MultipartRequestListener
 {
@@ -20,7 +20,7 @@ class MultipartRequestListener
         $this->injectFirstPart = $injectFirstPart;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         try {
             $this->processRequest($event->getRequest());

--- a/tests/DependencyInjection/MultipartRequestListenerTest.php
+++ b/tests/DependencyInjection/MultipartRequestListenerTest.php
@@ -6,7 +6,7 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 
 class MultipartRequestListenerTest extends AbstractExtensionTestCase
 {
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return array(
             new GoetasMultipartUploadExtension()

--- a/tests/EventListener/MultipartRequestListenerTest.php
+++ b/tests/EventListener/MultipartRequestListenerTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 use Riverline\MultiPartParser\StreamedPart;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class MultipartRequestListenerTest extends TestCase
 {
     /**
-     * @var GetResponseEvent
+     * @var RequestEvent
      */
     private $event;
 
@@ -29,12 +29,12 @@ class MultipartRequestListenerTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->listener = new MultipartRequestListener();
 
         $this->request = new Request();
-        $this->event = new GetResponseEvent(new TestKernel(), $this->request, HttpKernelInterface::MASTER_REQUEST);
+        $this->event = new RequestEvent(new TestKernel(), $this->request, HttpKernelInterface::MASTER_REQUEST);
     }
 
     public function testFormDataIsNotTouched()


### PR DESCRIPTION
Fixes https://github.com/goetas/MultipartUploadBundle/issues/12

Updated composer.json to allow install on Symfony5 and PHP8
Upgraded PhpUnit to PhpUnit9 because phpunit7 is incompatible with php8
Dropped support on PHP7.0 because of incopatibility of phpunit9

Tests are failing because of a deprecation notice on php8, it was fixed on Symfony 5.2.4.
is there a was to ignore this error on php8 only?